### PR TITLE
Remove DockerDaemonException

### DIFF
--- a/UPISAS/exceptions.py
+++ b/UPISAS/exceptions.py
@@ -2,10 +2,6 @@ class UPISASException(Exception):
     pass
 
 
-class DockerDaemonNotRunning(UPISASException):
-    pass
-
-
 class DockerImageNotFoundOnDockerHub(UPISASException):
     pass
 

--- a/UPISAS/exceptions.py
+++ b/UPISAS/exceptions.py
@@ -2,7 +2,7 @@ class UPISASException(Exception):
     pass
 
 
-class DockerDeamonNotRunning(UPISASException):
+class DockerDaemonNotRunning(UPISASException):
     pass
 
 

--- a/UPISAS/exemplar.py
+++ b/UPISAS/exemplar.py
@@ -4,7 +4,7 @@ from rich.progress import Progress
 from UPISAS import show_progress
 import logging
 from docker.errors import DockerException
-from UPISAS.exceptions import DockerImageNotFoundOnDockerHub, DockerDeamonNotRunning
+from UPISAS.exceptions import DockerImageNotFoundOnDockerHub, DockerDaemonNotRunning
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -41,9 +41,8 @@ class Exemplar(ABC):
             docker_kwargs["detach"] = True
             self.exemplar_container = docker_client.containers.create(**docker_kwargs)
         except DockerException as e:
-            logging.error("A DockerException occurred, are you sure the Docker deamon is running?")
-            logging.error(e)
-            raise DockerDeamonNotRunning
+            logging.error(f"A DockerException occurred: {e}")
+            raise DockerDaemonNotRunning
         if auto_start:
             self.start_container()
 

--- a/UPISAS/exemplar.py
+++ b/UPISAS/exemplar.py
@@ -4,7 +4,7 @@ from rich.progress import Progress
 from UPISAS import show_progress
 import logging
 from docker.errors import DockerException
-from UPISAS.exceptions import DockerImageNotFoundOnDockerHub, DockerDaemonNotRunning
+from UPISAS.exceptions import DockerImageNotFoundOnDockerHub
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -41,8 +41,9 @@ class Exemplar(ABC):
             docker_kwargs["detach"] = True
             self.exemplar_container = docker_client.containers.create(**docker_kwargs)
         except DockerException as e:
-            logging.error(f"A DockerException occurred: {e}")
-            raise DockerDaemonNotRunning
+            # TODO: Properly catch various errors. Currently, a lot of errors might be caught here.
+            # Please check the logs if that happens.
+            raise e
         if auto_start:
             self.start_container()
 


### PR DESCRIPTION
Currently, the `try catch` catches a lot of different errors and could potentially mislead the user. In this PR, I have removed the error and simply wrote a TODO comment. This TODO comment could technically be removed as well as the `try catch` structure is currently ineffective. I, however, left it in as it is a potential spot improvements could be made to the framework.

If it is not wanted, it can easily be edited out.