### PR TITLE
fix execute strategy

### DIFF
--- a/UPISAS/strategy.py
+++ b/UPISAS/strategy.py
@@ -34,14 +34,17 @@ class Strategy(ABC):
         return True
 
     def execute(self, adaptation, endpoint_suffix="execute", with_validation=True):
-        if with_validation:
-            validate_schema(adaptation, self.knowledge.execute_schema)
+        # * Uncomment if you want to validate adaptation input against adaptation_options_schema
+        # if with_validation:
+        #     validate_schema(adaptation, self.knowledge.adaptation_options_schema)
         url = '/'.join([self.exemplar.base_endpoint, endpoint_suffix])
         response = requests.put(url, json=adaptation)
         print("[Execute]\tposted configuration: " + str(adaptation))
         if response.status_code == 404:
             logging.error("Cannot execute adaptation on remote system, check that the execute endpoint exists.")
             raise EndpointNotReachable
+        if with_validation:
+            validate_schema(response.json(), self.knowledge.execute_schema)
         return True
 
     def get_adaptation_options(self, endpoint_suffix: "API Endpoint" = "adaptation_options", with_validation=True):


### PR DESCRIPTION
# Reason for pull request
After discussion with the TA about the execute strategy, we came to the conclusion that the strategy in UPISAS is incorrect.

## Current behavior
It checks the adaptation_options input against the execute schema while we expect the input to be the adaptation from the adaptation endpoint.

## Expected behavior
* *Check adaptation input against adaptation_options_schema (not required because you would have to call the adaptation_options_schema first in the test)*
* Make a put request to execute with the adaptation_options
* Check the response from the request against the execute_schema