### PR TITLE
fix execute strategy and add try except

### DIFF
--- a/UPISAS/strategy.py
+++ b/UPISAS/strategy.py
@@ -34,14 +34,17 @@ class Strategy(ABC):
         return True
 
     def execute(self, adaptation, endpoint_suffix="execute", with_validation=True):
-        if with_validation:
-            validate_schema(adaptation, self.knowledge.execute_schema)
+        # * Uncomment if you want to validate adaptation input against adaptation_options_schema
+        # if with_validation:
+        #     validate_schema(adaptation, self.knowledge.adaptation_options_schema)
         url = '/'.join([self.exemplar.base_endpoint, endpoint_suffix])
         response = requests.put(url, json=adaptation)
         print("[Execute]\tposted configuration: " + str(adaptation))
         if response.status_code == 404:
             logging.error("Cannot execute adaptation on remote system, check that the execute endpoint exists.")
             raise EndpointNotReachable
+        if with_validation:
+            validate_schema(response.json(), self.knowledge.execute_schema)
         return True
 
     def get_adaptation_options(self, endpoint_suffix: "API Endpoint" = "adaptation_options", with_validation=True):

--- a/UPISAS/tests/your_exemplar/test_your_exemplar_interface.py
+++ b/UPISAS/tests/your_exemplar/test_your_exemplar_interface.py
@@ -4,7 +4,9 @@ import time
 from UPISAS import get_response_for_get_request
 from UPISAS.exemplars.your_exemplar import YourExemplar
 from UPISAS.strategies.empty_strategy import EmptyStrategy
+from UPISAS.exceptions import ServerNotReachable
 
+from requests.exceptions import RequestException
 
 class TestYourExemplarInterface(unittest.TestCase):
 
@@ -69,10 +71,17 @@ class TestYourExemplarInterface(unittest.TestCase):
         while True:
             time.sleep(1)
             print("trying to connect...")
-            response = get_response_for_get_request(base_endpoint)
-            print(response.status_code)
-            if response.status_code < 400:
-                return
+            try:
+                response = get_response_for_get_request(base_endpoint)
+                print(response.status_code)
+                if response.status_code < 400:
+                    return
+            except RequestException as e:
+                print(e)
+                print("retrying connection")
+            except ServerNotReachable as e:
+                print(e)
+                print("retrying connection")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Reason for pull request
After discussion with the TA about the execute strategy, we came to the conclusion that the strategy in UPISAS is incorrect.

## Current behavior
It checks the adaptation_options input against the execute schema while we expect the input to be the adaptation from the adaptation endpoint.

## Expected behavior
* *Check adaptation input against adaptation_options_schema (not required because you would have to call the adaptation_options_schema first in the test)*
* Make a put request to execute with the adaptation_options
* Check the response from the request against the execute_schema

## Additionally
Added try except in _start_server_and_wait_until_is_up to make sure it retries connection to the server after failure